### PR TITLE
enable deploy-dev workflow to be manually triggered

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -3,6 +3,7 @@ name: deploy-dev
 on:
   push:
     branches: ['dev']
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Description

We would like to push the latest code to dev. Generally, we can simply re-run the latest `deploy-dev` job. However, GitHub only allows a job to be [re-run until 30 days after its initial run](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/re-running-workflows-and-jobs). 

Here, we add the `workflow_dispatch` trigger, so that we can [manually trigger `deploy-dev` whenever desired](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch).