### PR TITLE
MG-510: upgrade pytest from 6.2.5 to 8.3.0 to fix typeguard compatibility issue in CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pre-commit~=3.8.0
-pytest==6.2.5
+pytest~=8.3.0


### PR DESCRIPTION
The `test` job recently [failed](https://github.com/Sage-Bionetworks-IT/modeladexplorer-infra/actions/runs/19241998165/job/55006731738). We need to upgrade `pytest` to fix a compatibility issue with `typeguard`. See [MG-510](https://sagebionetworks.jira.com/browse/MG-510) for info.

[MG-510]: https://sagebionetworks.jira.com/browse/MG-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ