### PR TITLE
MG-544: add model-ad-api-next to stack

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,14 +67,18 @@ if ghcr_package_version == "edge":
     api_version = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "model-ad-api"
     )
+    api_next_version = get_alternate_tag_for_edge_package_version(
+        "Sage-Bionetworks", "model-ad-api-next"
+    )
     apex_version = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "model-ad-apex"
     )
 else:
-    app_version = api_version = apex_version = ghcr_package_version
+    app_version = api_version = api_next_version = apex_version = ghcr_package_version
 
 print(
-    f"Using images: model-ad-app:{app_version}, model-ad-api:{api_version}, model-ad-apex:{apex_version}"
+    f"Using images: model-ad-app:{app_version}, model-ad-api:{api_version}, "
+    f"model-ad-api-next:{api_next_version}, model-ad-apex:{apex_version}"
 )
 
 # Define stacks
@@ -159,6 +163,42 @@ api_stack.service.connections.allow_to_default_port(
     "Allow API container to connect to DocumentDB cluster",
 )
 
+api_next_props = ServiceProps(
+    container_name="model-ad-api-next",
+    container_location=f"ghcr.io/sage-bionetworks/model-ad-api-next:{api_next_version}",
+    container_port=3334,
+    container_memory_reservation=2048,
+    container_env_vars={
+        "SERVER_PORT": "3334",
+        "SPRING_DATA_MONGODB_HOST": docdb_stack.cluster.cluster_endpoint.hostname,
+        "SPRING_DATA_MONGODB_PORT": f"{mongodb_port}",
+        "SPRING_DATA_MONGODB_DATABASE": "model-ad",
+        "SPRING_DATA_MONGODB_USERNAME": docdb_master_username,
+        "SPRING_DATA_MONGODB_AUTHENTICATION_DATABASE": "admin",
+        "SPRING_PROFILES_ACTIVE": f"{environment}",
+    },
+    container_secrets=[
+        ServiceSecret(
+            secret_name=docdb_stack.master_password_secret.secret_name,
+            environment_key="SPRING_DATA_MONGODB_PASSWORD",
+        )
+    ],
+    auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
+    auto_scale_max_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["max"],
+)
+api_next_stack = ServiceStack(
+    scope=cdk_app,
+    construct_id=f"{stack_name_prefix}-api-next",
+    vpc=network_stack.vpc,
+    cluster=ecs_stack.cluster,
+    props=api_next_props,
+)
+api_next_stack.add_dependency(docdb_stack)
+api_next_stack.service.connections.allow_to_default_port(
+    docdb_stack.cluster,
+    "Allow API Next container to connect to DocumentDB cluster",
+)
+
 app_props = ServiceProps(
     container_name="model-ad-app",
     container_location=f"ghcr.io/sage-bionetworks/model-ad-app:{app_version}",
@@ -167,6 +207,7 @@ app_props = ServiceProps(
     container_env_vars={
         "APP_VERSION": f"{app_version}",
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
+        # TODO: update this port when model-ad-api is removed from this stack
         "SSR_API_URL": "http://model-ad-api:3333/v1",
         "TAG_NAME": f"model-ad/v{app_version}",
         "GOOGLE_TAG_MANAGER_ID": "GTM-K5BLKJH5",
@@ -182,6 +223,7 @@ app_stack = ServiceStack(
     props=app_props,
 )
 app_stack.add_dependency(api_stack)
+app_stack.add_dependency(api_next_stack)
 
 apex_props = ServiceProps(
     container_name="model-ad-apex",
@@ -193,6 +235,8 @@ apex_props = ServiceProps(
         "API_PORT": "3333",
         "APP_HOST": "model-ad-app",
         "APP_PORT": "4200",
+        "API_NEXT_HOST": "model-ad-api-next",
+        "API_NEXT_PORT": "3334",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
     auto_scale_max_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["max"],
@@ -209,6 +253,7 @@ apex_stack = LoadBalancedServiceStack(
 )
 apex_stack.add_dependency(app_stack)
 apex_stack.add_dependency(api_stack)
+apex_stack.add_dependency(api_next_stack)
 
 bastion_props = BastionProps(
     key_name="agora-access",


### PR DESCRIPTION
[MG-544](https://sagebionetworks.jira.com/browse/MG-544): We are migrating from a Node.js Express server to a Java Spring Boot server. We are moving routes to the new server gradually. However, we would like the deployed app to continue functioning while the routes are migrated. This PR adds the new server (`model-ad-api-next`) to the stack. We plan to remove the old server (`model-ad-api`) in the future when all routes have been migrated. 

> [!IMPORTANT] 
> These changes should not be merged until after we deploy to stage in preparation for a demo on Friday. 

[MG-544]: https://sagebionetworks.jira.com/browse/MG-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ