### PR TITLE
feat(model-ad): add SENTRY_ENVIRONMENT var (MG-796)

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,6 +205,7 @@ app_props = ServiceProps(
         # TODO: update this port when model-ad-api is removed from this stack
         "SSR_API_URL": "http://model-ad-api:3333/v1",
         "GOOGLE_TAG_MANAGER_ID": "GTM-K5BLKJH5",
+        "SENTRY_ENVIRONMENT": environment,
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
     auto_scale_max_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["max"],


### PR DESCRIPTION
## Description
This PR adds SENTRY_ENVIRONMENT variable to move current environment detection logic to deployment pipeline

## Related Issues
[MG-796](https://sagebionetworks.jira.com/browse/MG-796)


[MG-796]: https://sagebionetworks.jira.com/browse/MG-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ