### PR TITLE
feat(model-ad): add sentry environment var (MG-796)

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,6 +207,12 @@ app_props = ServiceProps(
         "GOOGLE_TAG_MANAGER_ID": "GTM-K5BLKJH5",
         "SENTRY_ENVIRONMENT": environment,
     },
+    container_secrets=[
+        ServiceSecret(
+            secret_name="model-ad-sentry-dsn",
+            environment_key="SENTRY_DSN",
+        )
+    ],
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
     auto_scale_max_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["max"],
 )


### PR DESCRIPTION
## Description
This PR adds the Sentry environment variable to the deployment pipeline.

## Related Issues
[MG-796](https://sagebionetworks.jira.com/browse/MG-796)


[MG-796]: https://sagebionetworks.jira.com/browse/MG-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ