### PR TITLE
feat(model-ad): add sentry release info (MG-883)

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,6 +206,7 @@ app_props = ServiceProps(
         "SSR_API_URL": "http://model-ad-api:3333/v1",
         "GOOGLE_TAG_MANAGER_ID": "GTM-K5BLKJH5",
         "SENTRY_ENVIRONMENT": environment,
+        "SENTRY_RELEASE": f"model-ad@{ghcr_package_version}+{short_commit_sha}",
     },
     container_secrets=[
         ServiceSecret(


### PR DESCRIPTION
### Description

This PR sets SENTRY_RELEASE on the container

Per Sentry's [naming releases](https://docs.sentry.io/product/releases/naming-releases/) documentation, release identifiers must follow 1 of 2 conventions.  The semantic versioning form is followed:

Semantic versioning form: package@version or package@version+build — e.g., model-ad@0.9.0-rc1+1234567

### Issues
[MG-884](https://sagebionetworks.jira.com/browse/MG-884)

[MG-884]: https://sagebionetworks.jira.com/browse/MG-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ