### PR TITLE
feat(model-ad): align with recent agora hardening changes (MG-911)

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -3,7 +3,7 @@ name: aws-deploy
 
 # Ensures that only one deploy task per branch/environment will run at a time.
 concurrency:
-  group: ${{ inputs.environment }}
+  group: ${{ inputs.aws-environment }}
   cancel-in-progress: false
 
 on:
@@ -21,7 +21,7 @@ on:
       role-duration-seconds:
         type: number
         default: 3600
-      environment:
+      aws-environment:
         required: true
         type: string
 
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   deploy:
+    environment: ${{ inputs.aws-environment }}
     permissions:
       id-token: write
       contents: read
@@ -38,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.environment }}
+          ref: ${{ inputs.aws-environment }}
       - name: Install AWS CLI
         run: sudo snap install aws-cli --classic
       - name: Install AWS CDK CLI
@@ -60,5 +61,5 @@ jobs:
       - name: CDK deploy
         run: uv run cdk deploy --all --debug --concurrency 5 --require-approval never
         env:
-          ENV: ${{ inputs.environment }}
+          ENV: ${{ inputs.aws-environment }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -12,7 +12,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: dev
+      aws-environment: dev
+      ref: dev  # git branch to check out
   aws-deploy:
     needs: test
     permissions:
@@ -22,4 +23,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::607346494281:role/sagebase-github-oidc-modeladexplorer-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: dev
+      aws-environment: dev

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -11,7 +11,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: prod
+      aws-environment: prod
+      ref: prod  # git branch to check out
   aws-deploy:
     needs: test
     permissions:
@@ -21,4 +22,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-modeladexplorer-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: prod
+      aws-environment: prod

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -11,7 +11,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: stage
+      aws-environment: stage
+      ref: stage  # git branch to check out
   aws-deploy:
     needs: test
     permissions:
@@ -21,4 +22,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-modeladexplorer-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: stage
+      aws-environment: stage

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -11,4 +11,5 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: dev
+      aws-environment: dev
+      # ref intentionally omitted: defaults to '' so checkout uses the PR head

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,18 @@ name: test
 on:
   workflow_call:
     inputs:
-      environment:
+      # aws-environment accepts one of three values:
+      #   'dev' / 'stage' / 'prod' - the AWS deployment target
+      aws-environment:
         required: true
         type: string
+      # ref accepts one of four values:
+      #   'dev' / 'stage' / 'prod' - pin checkout to that env branch  (deploy-*.yaml)
+      #   ''                       - check out the PR's commit        (pr-check.yaml; ref omitted)
+      ref:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -16,8 +25,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version-file: pyproject.toml
       - name: Run uv-audit hook
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
@@ -27,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -41,6 +56,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install AWS CDK CLI
         run: npm install -g aws-cdk@2.1007.0 --ignore-scripts
       - name: Set up uv
@@ -52,6 +69,6 @@ jobs:
         run: uv sync --frozen --no-group dev
       - name: Generate cloudformation
         env:
-          ENV: ${{ inputs.environment }}
+          ENV: ${{ inputs.aws-environment }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run cdk synth --debug --output ./cdk.out

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All the development tools are provided when developing inside the dev container
 also include a Python virtual environment where all the Python packages needed
 are already installed.
 
-If you decide the develop outside of the dev container, you'll need
+If you decide to develop outside of the dev container, you'll need
 [uv](https://docs.astral.sh/uv/getting-started/installation/) installed.
 Then run:
 
@@ -51,7 +51,7 @@ Then run:
 This creates a `.venv` and installs Python dependencies from `uv.lock`.
 Run Python commands via `uv run` so they execute inside the managed env:
 
-```
+```console
 $ uv run cdk synth
 ```
 


### PR DESCRIPTION
## Summary

Mirrors the hardening done in [agora-infra-v3#92](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/pull/92) (AG-2095) to keep the two repos aligned.

Rename the reusable-workflow input environment → aws-environment across test.yaml, aws-deploy.yaml, and the three deploy-*.yaml callers + pr-check.yaml. The old name collided with GitHub's built-in environment: job key.
Add environment: ${{ inputs.aws-environment }} at the job level in aws-deploy.yaml so deploys are gated by GitHub environment protection rules (required reviewers / secrets scoping).
Add an optional ref input to test.yaml and propagate it to every actions/checkout step:
deploy-dev.yaml / deploy-stage.yaml / deploy-prod.yaml pass ref: dev|stage|prod so tests run against the same branch we're about to deploy.
pr-check.yaml omits ref (defaults to ''), so checkout still resolves to the PR head.
Align README Development section wording with agora-infra-v3 (typo fix decide the develop → decide to develop, plus uv-install instructions and a console language hint on the synth code fence). All model-ad-specific content (project name, URLs, monorepo references) preserved.

## Post-merge environment configuration
Environment protection rules will be configured post-merge.
