### PR TITLE
update stage and prod certificate to support apex domain (MG-901)

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ match environment:
         environment_variables = {
             "VPC_CIDR": "10.253.174.0/24",
             "FQDN": "prod.modeladexplorer.org",
-            "CERTIFICATE_ID": "dac041fd-e947-4684-a910-fa343adeac33",
+            "CERTIFICATE_ID": "0983d5d7-6480-4292-b4bc-947712f248b0",
             "TAGS": {"CostCenter": "Model AD-UCI / 123300", "Environment": "prod"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "1.0.0",
@@ -31,7 +31,7 @@ match environment:
         environment_variables = {
             "VPC_CIDR": "10.253.173.0/24",
             "FQDN": "stage.modeladexplorer.org",
-            "CERTIFICATE_ID": "dac041fd-e947-4684-a910-fa343adeac33",
+            "CERTIFICATE_ID": "0983d5d7-6480-4292-b4bc-947712f248b0",
             "TAGS": {"CostCenter": "Model AD-IU / 123200", "Environment": "stage"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -207,11 +207,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The existing stage/prod ALB certificate only covers `*.modeladexplorer.org` and does not include the apex domain `modeladexplorer.org`. This PR updates the stage and prod environments to use a new certificate that covers both `*.modeladexplorer.org` and `modeladexplorer.org`, which is a prerequisite for pointing the apex domain directly at the ALB as part of the [MG-901](https://sagebionetworks.jira.com/browse/MG-901) cutover plan.

[MG-901]: https://sagebionetworks.jira.com/browse/MG-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ