### PR TITLE
update prod FQDN to apex domain and add ALB redirect rule for prod subdomain (MG-901)

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,11 +21,12 @@ match environment:
     case "prod":
         environment_variables = {
             "VPC_CIDR": "10.253.174.0/24",
-            "FQDN": "prod.modeladexplorer.org",
+            "FQDN": "modeladexplorer.org",
             "CERTIFICATE_ID": "0983d5d7-6480-4292-b4bc-947712f248b0",
             "TAGS": {"CostCenter": "Model AD-UCI / 123300", "Environment": "prod"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "1.0.0",
+            "REDIRECT_FROM_HOSTNAME": "prod.modeladexplorer.org",
         }
     case "stage":
         environment_variables = {
@@ -35,6 +36,7 @@ match environment:
             "TAGS": {"CostCenter": "Model AD-IU / 123200", "Environment": "stage"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "1.0.0",
+            "REDIRECT_FROM_HOSTNAME": None,
         }
     case "dev":
         environment_variables = {
@@ -44,6 +46,7 @@ match environment:
             "TAGS": {"CostCenter": "Model AD-IU / 123200", "Environment": "dev"},
             "AUTO_SCALE_CAPACITY": {"min": 1, "max": 2},
             "GHCR_PACKAGE_VERSION": "edge",
+            "REDIRECT_FROM_HOSTNAME": None,
         }
     case _:
         valid_envs_str = ",".join(VALID_ENVIRONMENTS)
@@ -252,6 +255,8 @@ apex_stack = LoadBalancedServiceStack(
     load_balancer=load_balancer_stack.alb,
     certificate_id=environment_variables["CERTIFICATE_ID"],
     health_check_path="/health",
+    redirect_from_hostname=environment_variables["REDIRECT_FROM_HOSTNAME"],
+    redirect_to_hostname=fully_qualified_domain_name,
 )
 apex_stack.add_dependency(app_stack)
 apex_stack.add_dependency(api_stack)

--- a/app.py
+++ b/app.py
@@ -59,6 +59,8 @@ stack_name_prefix = f"model-ad-{environment}"
 fully_qualified_domain_name = environment_variables["FQDN"]
 environment_tags = environment_variables["TAGS"]
 ghcr_package_version = environment_variables["GHCR_PACKAGE_VERSION"]
+redirect_from_hostname = environment_variables["REDIRECT_FROM_HOSTNAME"]
+redirect_to_hostname = fully_qualified_domain_name if redirect_from_hostname else None
 docdb_master_username = "master"
 mongodb_port = 27017
 vpn_cidr = "10.1.0.0/16"
@@ -255,8 +257,8 @@ apex_stack = LoadBalancedServiceStack(
     load_balancer=load_balancer_stack.alb,
     certificate_id=environment_variables["CERTIFICATE_ID"],
     health_check_path="/health",
-    redirect_from_hostname=environment_variables["REDIRECT_FROM_HOSTNAME"],
-    redirect_to_hostname=fully_qualified_domain_name,
+    redirect_from_hostname=redirect_from_hostname,
+    redirect_to_hostname=redirect_to_hostname,
 )
 apex_stack.add_dependency(app_stack)
 apex_stack.add_dependency(api_stack)

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -220,6 +220,8 @@ class LoadBalancedServiceStack(ServiceStack):
         certificate_id: str,
         health_check_path: str = "/",
         health_check_interval: int = 1,  # max is 5
+        redirect_from_hostname: str | None = None,
+        redirect_to_hostname: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, vpc, cluster, props, **kwargs)
@@ -256,6 +258,26 @@ class LoadBalancedServiceStack(ServiceStack):
                 path=health_check_path, interval=duration.minutes(health_check_interval)
             ),
         )
+
+        if bool(redirect_from_hostname) != bool(redirect_to_hostname):
+            raise ValueError(
+                "redirect_from_hostname and redirect_to_hostname must both be set or both be None"
+            )
+
+        if redirect_from_hostname and redirect_to_hostname:
+            https_listener.add_action(
+                "SubdomainRedirect",
+                priority=1,  # unique per listener; increment if more rules are added
+                conditions=[
+                    elbv2.ListenerCondition.host_headers([redirect_from_hostname])
+                ],
+                action=elbv2.ListenerAction.redirect(
+                    host=redirect_to_hostname,
+                    port=str(ALB_HTTPS_LISTENER_PORT),
+                    protocol=elbv2.ApplicationProtocol.HTTPS.value,
+                    permanent=True,
+                ),
+            )
 
         # -------------------------------
         # redirect http to https

--- a/tests/unit/test_service_stack.py
+++ b/tests/unit/test_service_stack.py
@@ -1,10 +1,38 @@
+import pytest
 import aws_cdk as cdk
 import aws_cdk.assertions as assertions
 
 from src.network_stack import NetworkStack
 from src.ecs_stack import EcsStack
+from src.load_balancer_stack import LoadBalancerStack
 from src.service_props import ServiceProps, ServiceSecret, ContainerVolume
-from src.service_stack import ServiceStack
+from src.service_stack import LoadBalancedServiceStack, ServiceStack
+
+FAKE_CERT_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _make_load_balanced_stack(redirect_from=None, redirect_to=None):
+    app = cdk.App()
+    network_stack = NetworkStack(app, "NetworkStack", vpc_cidr="10.254.192.0/24")
+    ecs_stack = EcsStack(app, "EcsStack", vpc=network_stack.vpc, namespace="dev.app.io")
+    lb_stack = LoadBalancerStack(app, "LbStack", vpc=network_stack.vpc)
+    props = ServiceProps(
+        container_name="apex",
+        container_location="ghcr.io/sage-bionetworks/apex:1.0",
+        container_port=80,
+        container_memory_reservation=200,
+    )
+    return LoadBalancedServiceStack(
+        scope=app,
+        construct_id="ApexStack",
+        vpc=network_stack.vpc,
+        cluster=ecs_stack.cluster,
+        props=props,
+        load_balancer=lb_stack.alb,
+        certificate_id=FAKE_CERT_ID,
+        redirect_from_hostname=redirect_from,
+        redirect_to_hostname=redirect_to,
+    )
 
 
 def test_service_stack_created():
@@ -52,5 +80,52 @@ def test_service_stack_created():
                     "HealthCheck": {"Command": ["CMD", "/healthcheck"]},
                 }
             ]
+        },
+    )
+
+
+def test_load_balanced_service_stack_raises_when_only_redirect_from_set():
+    with pytest.raises(ValueError):
+        _make_load_balanced_stack(redirect_from="prod.modeladexplorer.org")
+
+
+def test_load_balanced_service_stack_raises_when_only_redirect_to_set():
+    with pytest.raises(ValueError):
+        _make_load_balanced_stack(redirect_to="modeladexplorer.org")
+
+
+def test_load_balanced_service_stack_no_redirect_rule_by_default():
+    stack = _make_load_balanced_stack()
+    template = assertions.Template.from_stack(stack)
+    template.resource_count_is("AWS::ElasticLoadBalancingV2::ListenerRule", 0)
+
+
+def test_load_balanced_service_stack_redirect_rule_created():
+    stack = _make_load_balanced_stack(
+        redirect_from="prod.modeladexplorer.org",
+        redirect_to="modeladexplorer.org",
+    )
+    template = assertions.Template.from_stack(stack)
+    template.has_resource_properties(
+        "AWS::ElasticLoadBalancingV2::ListenerRule",
+        {
+            "Priority": 1,
+            "Conditions": [
+                {
+                    "Field": "host-header",
+                    "HostHeaderConfig": {"Values": ["prod.modeladexplorer.org"]},
+                }
+            ],
+            "Actions": [
+                {
+                    "Type": "redirect",
+                    "RedirectConfig": {
+                        "Host": "modeladexplorer.org",
+                        "Port": "443",
+                        "Protocol": "HTTPS",
+                        "StatusCode": "HTTP_301",
+                    },
+                }
+            ],
         },
     )


### PR DESCRIPTION
This PR updates the prod canonical URL from `prod.modeladexplorer.org` to `modeladexplorer.org` and adds an ALB listener rule that permanently redirects `prod.modeladexplorer.org` to `modeladexplorer.org`, preserving old share URLs. This PR should be merged to `dev` and `stage` ahead of time, but the `stage` → `prod` merge must be held until the PR in organizations-infra to replace the `ModeladexplorerRedirect` with an ALIAS record pointing `modeladexplorer.org` directly at the prod ALB is live to avoid a redirect loop. See [MG-901](https://sagebionetworks.jira.com/browse/MG-901) for more context.

[MG-901]: https://sagebionetworks.jira.com/browse/MG-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ