### PR TITLE
fix(model-ad): restore GA4 analytics and scope GTM container to prod only (MG-916, MG-917)

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,8 @@ match environment:
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "1.0.0",
             "REDIRECT_FROM_HOSTNAME": "prod.modeladexplorer.org",
+            "GTM_ENABLED": "true",
+            "GTM_CONTAINER_ID": "GTM-K5BLKJH5",
         }
     case "stage":
         environment_variables = {
@@ -37,6 +39,8 @@ match environment:
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "1.0.0",
             "REDIRECT_FROM_HOSTNAME": None,
+            "GTM_ENABLED": "false",
+            "GTM_CONTAINER_ID": "",
         }
     case "dev":
         environment_variables = {
@@ -47,6 +51,8 @@ match environment:
             "AUTO_SCALE_CAPACITY": {"min": 1, "max": 2},
             "GHCR_PACKAGE_VERSION": "edge",
             "REDIRECT_FROM_HOSTNAME": None,
+            "GTM_ENABLED": "false",
+            "GTM_CONTAINER_ID": "",
         }
     case _:
         valid_envs_str = ",".join(VALID_ENVIRONMENTS)
@@ -210,7 +216,8 @@ app_props = ServiceProps(
         # TODO: update this port when model-ad-api is removed from this stack
         "SSR_API_URL": "http://model-ad-api:3333/v1",
         "ENVIRONMENT": environment,
-        "GOOGLE_TAG_MANAGER_ID": "GTM-K5BLKJH5",
+        "GOOGLE_TAG_MANAGER_ENABLED": environment_variables["GTM_ENABLED"],
+        "GOOGLE_TAG_MANAGER_ID": environment_variables["GTM_CONTAINER_ID"],
         "SENTRY_ENVIRONMENT": environment,
         "SENTRY_RELEASE": f"model-ad@{ghcr_package_version}+{short_commit_sha}",
     },

--- a/app.py
+++ b/app.py
@@ -209,6 +209,7 @@ app_props = ServiceProps(
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         # TODO: update this port when model-ad-api is removed from this stack
         "SSR_API_URL": "http://model-ad-api:3333/v1",
+        "ENVIRONMENT": environment,
         "GOOGLE_TAG_MANAGER_ID": "GTM-K5BLKJH5",
         "SENTRY_ENVIRONMENT": environment,
         "SENTRY_RELEASE": f"model-ad@{ghcr_package_version}+{short_commit_sha}",


### PR DESCRIPTION
## Description

Since the CDK app in infra does not set the `ENVIRONMENT` variable, so all environments are falling back to the dev defaults that disable Google Tag Manager. This PR adds the `ENVIRONMENT` variable to the app container so the app will pick the correct profile per environment, and parameterizes the GTM container ID per environment so dev and stage no longer send events to the production GA4 property.

## Related Issue

- [MG-916](https://sagebionetworks.jira.com/browse/MG-916)
- [MG-917](https://sagebionetworks.jira.com/browse/MG-917) 

## Changelog

- Set `ENVIRONMENT` on the app container so the SSR config loader resolves the correct profile per env
- Move `GOOGLE_TAG_MANAGER_ID` and `GOOGLE_TAG_MANAGER_ENABLED` into the per-env `environment_variables` block in `app.py`
- Enable Google Tag Manager only on prod; disable on dev and stage until separate GTM containers exist


[MG-916]: https://sagebionetworks.jira.com/browse/MG-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-917]: https://sagebionetworks.jira.com/browse/MG-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ