### PR TITLE
fix: update all aws-cdk versions to align with aws-cdk-lib

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install AWS CLI
         run: sudo snap install aws-cli --classic
       - name: Install AWS CDK CLI
-        run: npm install -g aws-cdk@2.1007.0 --ignore-scripts
+        run: npm install -g aws-cdk@2.1135.1 --ignore-scripts
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -34,7 +34,7 @@ if ! command -v uv >/dev/null; then
 fi
 
 # Install Node.js dependencies
-npm install -g aws-cdk@2.1007.0 --ignore-scripts
+npm install -g aws-cdk@2.1135.1 --ignore-scripts
 
 # Install Python dependencies (creates .venv, installs from uv.lock)
 uv sync


### PR DESCRIPTION
#74 updated the CDK CLI version to >= 2.1125.0 to support the cloud assembly schema used by aws-cdk-lib 2.253.0 in `test.yaml`, but not in all locations. This PR ensures that `aws-cdk` is updated across the repo.