### PR TITLE
fix: build container from local source when container_location uses path://

### DIFF
--- a/src/service_props.py
+++ b/src/service_props.py
@@ -52,6 +52,10 @@ class ServiceProps:
     container_location:
       supports "path://" for building container from local (i.e. path://docker/MyContainer)
       supports docker registry references (i.e. ghcr.io/sage-bionetworks/app:latest)
+      the "path://" prefix is stripped, so `container_location_is_path` records whether
+      it was present
+    container_location_is_path: True when container_location was a "path://" reference
+      and the container should be built from local source
     container_port: the container application port
     container_memory_reservation: the soft limit of memory to reserve from the task memory for the container application
     container_env_vars: a json dictionary of environment variables to pass into the container
@@ -81,7 +85,10 @@ class ServiceProps:
         self.container_name = container_name
         self.container_port = container_port
         self.container_memory_reservation = container_memory_reservation
-        if CONTAINER_LOCATION_PATH_ID in container_location:
+        self.container_location_is_path = container_location.startswith(
+            CONTAINER_LOCATION_PATH_ID
+        )
+        if self.container_location_is_path:
             container_location = container_location.removeprefix(
                 CONTAINER_LOCATION_PATH_ID
             )

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -90,10 +90,10 @@ class ServiceStack(cdk.Stack):
             execution_role=execution_role,
         )
 
-        image = ecs.ContainerImage.from_registry(props.container_location)
-        if "path://" in props.container_location:  # build container from source
-            location = props.container_location.removeprefix("path://")
-            image = ecs.ContainerImage.from_asset(location)
+        if props.container_location_is_path:  # build container from source
+            image = ecs.ContainerImage.from_asset(props.container_location)
+        else:
+            image = ecs.ContainerImage.from_registry(props.container_location)
 
         def _get_secret(scope: Construct, id: str, name: str) -> sm.Secret:
             """Get a secret from the AWS secrets manager"""

--- a/tests/unit/test_service_props.py
+++ b/tests/unit/test_service_props.py
@@ -1,0 +1,23 @@
+from src.service_props import ServiceProps
+
+
+def test_service_props_flags_path_location():
+    props = ServiceProps(
+        container_name="app",
+        container_location="path://docker/app",
+        container_port=8010,
+    )
+
+    assert props.container_location == "docker/app"
+    assert props.container_location_is_path is True
+
+
+def test_service_props_registry_location_is_not_a_path():
+    props = ServiceProps(
+        container_name="app",
+        container_location="ghcr.io/sage-bionetworks/app:1.0",
+        container_port=8010,
+    )
+
+    assert props.container_location == "ghcr.io/sage-bionetworks/app:1.0"
+    assert props.container_location_is_path is False

--- a/tests/unit/test_service_stack.py
+++ b/tests/unit/test_service_stack.py
@@ -84,6 +84,43 @@ def test_service_stack_created():
     )
 
 
+def test_service_stack_builds_container_from_local_path(tmp_path):
+    (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+
+    cdk_app = cdk.App()
+    network_stack = NetworkStack(cdk_app, "NetworkStack", vpc_cidr="10.254.192.0/24")
+    ecs_stack = EcsStack(
+        cdk_app, "EcsStack", vpc=network_stack.vpc, namespace="dev.app.io"
+    )
+
+    app_props = ServiceProps(
+        container_name="app",
+        container_location=f"path://{tmp_path}",
+        container_port=8010,
+        container_memory_reservation=200,
+    )
+    app_stack = ServiceStack(
+        scope=cdk_app,
+        construct_id="app",
+        vpc=network_stack.vpc,
+        cluster=ecs_stack.cluster,
+        props=app_props,
+    )
+
+    # A container built from source is published as a CDK ECR asset, so the image
+    # is a CloudFormation intrinsic rather than the registry string it would be
+    # if the location were treated as a registry reference.
+    template = assertions.Template.from_stack(app_stack).to_json()
+    task_definitions = [
+        resource
+        for resource in template["Resources"].values()
+        if resource["Type"] == "AWS::ECS::TaskDefinition"
+    ]
+    image = task_definitions[0]["Properties"]["ContainerDefinitions"][0]["Image"]
+    assert isinstance(image, dict), f"expected an ECR asset reference, got {image!r}"
+    assert "container-assets" in image["Fn::Sub"]
+
+
 def test_load_balanced_service_stack_raises_when_only_redirect_from_set():
     with pytest.raises(ValueError):
         _make_load_balanced_stack(redirect_from="prod.modeladexplorer.org")


### PR DESCRIPTION
This PR proposes restoring `ServiceProps`' documented `path://` support so a container configured with a local path is built from source instead of being pulled from a registry. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/225. You can sign in with your GitHub ID to claim ownership of the project.

## What was broken

`ServiceProps.__init__` strips the `path://` prefix from `container_location` before it is stored:

```python
# src/service_props.py
if CONTAINER_LOCATION_PATH_ID in container_location:
    container_location = container_location.removeprefix(CONTAINER_LOCATION_PATH_ID)
self.container_location = container_location
```

`ServiceStack` then tests the already-stripped value for that same prefix, so the branch it guards is unreachable:

```python
# src/service_stack.py
image = ecs.ContainerImage.from_registry(props.container_location)
if "path://" in props.container_location:  # build container from source
    location = props.container_location.removeprefix("path://")
    image = ecs.ContainerImage.from_asset(location)
```

The result is that `container_location="path://docker/MyContainer"` — the exact form the `ServiceProps` docstring documents — never reaches `ContainerImage.from_asset()`. It synthesizes as `"Image": "docker/MyContainer"`, a registry reference. Nothing fails at synth time, so the mistake surfaces much later as an ECS image pull error against an image that was never published.

## Reproducing it on `dev`

Building a `ServiceStack` from a `path://` location on current `dev` (`77e43bf`) and reading the image out of the synthesized `AWS::ECS::TaskDefinition`:

```console
$ uv run python repro.py
Image: "/var/folders/0f/rfl3k4mj5nq95vf0s_y7nc6c0000gq/T/tmpz_165186"
```

That is the local directory being handed to `from_registry()`. With this change the same script emits an ECR asset reference, which is what a container built from source looks like:

```console
$ uv run python repro.py
Image: {"Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-${AWS::AccountId}-${AWS::Region}:250c4bd2c110b4..."}
```

A useful side effect: because the location now reaches `from_asset()`, a `path://` pointing at a directory that does not exist fails loudly during `cdk synth` with `CannotFindImageDirectory` rather than deploying a task that cannot start.

## The change

`ServiceProps` records whether the location was a `path://` reference in a new `container_location_is_path` attribute, and `ServiceStack` branches on that flag to choose `from_asset()` or `from_registry()`. This is deliberately additive and backward compatible: `container_location` keeps exactly the value it has today for every caller, and the prefix test moves from `in` to `startswith` only to match the `removeprefix()` that follows it — for a value such as `ghcr.io/x/path://y`, where `removeprefix()` was already a no-op, the stored location is unchanged.

## Verification

`tests/unit/test_service_stack.py::test_service_stack_builds_container_from_local_path` asserts the synthesized image is an ECR asset reference; on `dev` it fails with `expected an ECR asset reference, got '/private/var/.../test_service_stack_builds_cont0'`. Two small `tests/unit/test_service_props.py` cases cover the new attribute on both a `path://` and a registry location, and the existing `test_service_stack_created` remains the control for the registry path — its `"Image": "ghcr.io/sage-bionetworks/app:1.0"` assertion is untouched, which is the path `app.py` uses for all four services today.

Full suite before the change: 8 passed. After: 11 passed, no new failures. `pre-commit run --files src/service_props.py src/service_stack.py tests/unit/test_service_stack.py tests/unit/test_service_props.py` passes flake8, black, and the whitespace hooks.

## How this was managed

This work was tracked as a single story, https://eastagiletracker.com/projects/225/stories/88224, on a board imported from this repo's own issues and pull requests (75 stories, 5 labels): https://eastagiletracker.com/projects/225

![board](https://raw.githubusercontent.com/eastagiletracker/modeladexplorer-infra/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
